### PR TITLE
Add Reon language prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+# compiled examples
+examples/*.ts

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+# Reon Programming Language
+
+Reon (`.ro`) is an experimental layer on top of TypeScript. It offers a compact syntax for defining components, functions and printing values. The `reon` compiler converts `.ro` files to TypeScript so they can be compiled with existing tooling.
+
+## Syntax Overview
+
+### Components
+Use `component` to declare a class-like component.
+
+```ro
+component Greeter {
+  // members...
+}
+```
+
+Compiles to:
+
+```ts
+class Greeter {
+}
+```
+
+### Functions
+Define functions using the `fun` keyword followed by `=>` and an opening brace.
+
+```ro
+fun hello(name) => {
+  print("Hello, " + name);
+}
+```
+
+Compiles to:
+
+```ts
+hello(name) {
+  console.log("Hello, " + name);
+}
+```
+
+### Printing
+Use `print(expr)` to send output to the console. It compiles to `console.log`.
+
+```ro
+print("debug");
+```
+
+Compiles to:
+
+```ts
+console.log("debug");
+```
+
+## Getting Started
+
+1. Install dependencies and build the compiler:
+
+```bash
+npm install
+npm run build
+```
+
+2. Compile `.ro` files:
+
+```bash
+npx reon examples/hello.ro
+```
+
+This produces `examples/hello.ts` which can be processed by `tsc` or Node.js.
+
+## Status
+
+Reon is highly experimental and only demonstrates a minimal set of features built over TypeScript. Feel free to extend the compiler with additional syntax rules.

--- a/README.md
+++ b/README.md
@@ -50,6 +50,57 @@ Compiles to:
 console.log("debug");
 ```
 
+### Variables
+Declare constants using `val`.
+
+```ro
+val greeting = "hi";
+```
+
+Compiles to:
+
+```ts
+const greeting = "hi";
+```
+
+### Conditionals
+Use `if` with `=>` for blocks and optional `else`.
+
+```ro
+if x > 0 => {
+  print("positive");
+} else => {
+  print("negative");
+}
+```
+
+Compiles to:
+
+```ts
+if (x > 0) {
+  console.log("positive");
+} else {
+  console.log("negative");
+}
+```
+
+### Loops
+Iterate with a concise `for ... in ... =>` syntax.
+
+```ro
+for item in items => {
+  print(item);
+}
+```
+
+Compiles to:
+
+```ts
+for (const item of items) {
+  console.log(item);
+}
+```
+
 ## Getting Started
 
 1. Install dependencies and build the compiler:
@@ -63,9 +114,11 @@ npm run build
 
 ```bash
 npx reon examples/hello.ro
+npx reon examples/advanced.ro
 ```
 
-This produces `examples/hello.ts` which can be processed by `tsc` or Node.js.
+This produces `examples/hello.ts` and `examples/advanced.ts` which can be
+processed by `tsc` or Node.js.
 
 ## Status
 

--- a/examples/advanced.ro
+++ b/examples/advanced.ro
@@ -1,0 +1,11 @@
+component Counter {
+  fun run(nums) => {
+    for n in nums => {
+      if n > 0 => {
+        print("n: " + n);
+      } else => {
+        print("skip");
+      }
+    }
+  }
+}

--- a/examples/hello.ro
+++ b/examples/hello.ro
@@ -1,0 +1,5 @@
+component Greeter {
+  fun greet(name) => {
+    print("Hello, " + name);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,50 @@
+{
+  "name": "reon-lang",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "reon-lang",
+      "version": "0.1.0",
+      "bin": {
+        "reon": "dist/reon.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.15.30",
+        "typescript": "^5.0.0"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.30",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.30.tgz",
+      "integrity": "sha512-6Q7lr06bEHdlfplU6YRbgG1SFBdlsfNC4/lX+SkhiTs0cpJkOElmWls8PxDFv4yY/xKb8Y6SO0OmSX4wgqTZbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "reon-lang",
+  "version": "0.1.0",
+  "description": "Experimental Reon language compiler",
+  "main": "src/reon.js",
+  "bin": {
+    "reon": "dist/reon.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "test": "echo 'No tests yet'"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.30",
+    "typescript": "^5.0.0"
+  }
+}

--- a/src/reon.ts
+++ b/src/reon.ts
@@ -10,6 +10,18 @@ function compile(content: string): string {
   output = output.replace(/^(\s*)fun\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)\s*=>\s*\{/gm, '$1$2($3) {');
   // print(expr) -> console.log(expr)
   output = output.replace(/print\s*\(([^)]*)\);?/g, 'console.log($1);');
+  // val name = expr; -> const name = expr;
+  output = output.replace(/^\s*val\s+([A-Za-z0-9_]+)\s*=\s*([^;]+);/gm, 'const $1 = $2;');
+  // if condition => { -> if (condition) {
+  output = output.replace(/if\s+([^\{]+)\s*=>\s*\{/g, (_m, cond) => {
+    return `if (${String(cond).trim()}) {`;
+  });
+  // else => { -> else {
+  output = output.replace(/else\s*=>\s*\{/g, 'else {');
+  // for item in items => { -> for (const item of items) {
+  output = output.replace(/for\s+([A-Za-z0-9_]+)\s+in\s+([^\s\{]+)\s*=>\s*\{/g, (_m, item, arr) => {
+    return `for (const ${item} of ${String(arr).trim()}) {`;
+  });
   return output;
 }
 

--- a/src/reon.ts
+++ b/src/reon.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+import { readFileSync, writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+function compile(content: string): string {
+  let output = content;
+  // component -> class
+  output = output.replace(/component\s+([A-Za-z0-9_]+)\s*\{/g, 'class $1 {');
+  // fun name(args) => {  -> name(args) {
+  output = output.replace(/^(\s*)fun\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)\s*=>\s*\{/gm, '$1$2($3) {');
+  // print(expr) -> console.log(expr)
+  output = output.replace(/print\s*\(([^)]*)\);?/g, 'console.log($1);');
+  return output;
+}
+
+const inputPath = process.argv[2];
+if (!inputPath) {
+  console.error('Usage: reon <file.ro>');
+  process.exit(1);
+}
+
+const absIn = resolve(process.cwd(), inputPath);
+const input = readFileSync(absIn, 'utf-8');
+const compiled = compile(input);
+const outPath = absIn.replace(/\.ro$/, '.ts');
+writeFileSync(outPath, compiled, 'utf-8');
+console.log(`Compiled ${inputPath} -> ${outPath}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2019",
+    "module": "CommonJS",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+  "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- introduce minimal Reon compiler written in TypeScript
- document how Reon syntax works
- provide sample `.ro` file
- configure TypeScript project

## Testing
- `npm install`
- `npm run build`
- `npm test`
- `node dist/reon.js examples/hello.ro`


------
https://chatgpt.com/codex/tasks/task_e_6841ea42a2688325b70669df369b7438